### PR TITLE
chore: add .rspec file and configure RSpec in spec/rails_helper.rb and spec/spec_helper.rb

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+abort('The Rails environment is running in production mode!') if Rails.env.production?
+require 'rspec/rails'
+
+# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  abort e.to_s.strip
+end
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  config.use_transactional_fixtures = true
+
+  config.infer_spec_type_from_file_location!
+
+  config.filter_rails_from_backtrace!
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end


### PR DESCRIPTION
**problema**
Para os testes serem executados, é necessário a configuração do rspec.

**solução**
Conforme a documentação da `gem` sugere, foi gerado os arquivos `rails_helper` e `spec/spec_helper.rb` para que o rspec seja configurado corretamente.

Close #50 