### PR TITLE
chore(rails_helper.rb): adiciona configuração para FactoryBot

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,8 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.filter_rails_from_backtrace!
+
+  config.include FactoryBot::Syntax::Methods
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
**problema**
Toda vez que um `model` é gerado, será necessário criar factories para registrar dados no banco.

**solução**
Configurar a `FactoryBot` para agilizar na criação de registros dos testes

Close #52 