### PR TITLE
fix(content.rb): adicionando enum para status

### DIFF
--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -3,4 +3,6 @@ class Content < ApplicationRecord
   friendly_id :name, use: :slugged
 
   validates :name, :body, :description, :slug, presence: true
+
+  enum status: {draft: 0, publish: 1, review: 2}
 end

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     name        { Faker::Lorem.sentence(word_count: 3) }
     body        { Faker::Lorem.paragraph(sentence_count: 5) }
     description { Faker::Lorem.paragraph(sentence_count: 15) }
-    status      { 1 }
+    status      { :publish }
   end
 end

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe Content, type: :model do
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:slug) }
 
+    context 'should have specific status' do
+      it { should define_enum_for(:status) }
+      it do
+        should define_enum_for(:status).with_values %i[draft publish review]
+      end
+    end
+
     it 'should create slug' do
       content = create(:content, name: 'Creating columns in SQL database')
 


### PR DESCRIPTION
**problema**
Conteúdos não podem ser criados com os status ideal:

- Publicar
- Rascunho
- Analise

**solução**
Criar enum para o status dentro do modelo de conteúdos com os status requerido.

Close #58 