### PR TITLE
Visitante consegue visualizar página de conteúdos

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  protected
+
+  def not_found
+    render 'errors/404', status: :not_found
+  end
 end

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -1,0 +1,13 @@
+class ContentsController < ApplicationController
+  before_action :content_params, only: %i[show]
+
+  def show
+    return not_found unless @content.published?
+  end
+
+  private
+
+  def content_params
+    @content = Content.friendly.find(params[:id])
+  end
+end

--- a/app/views/contents/_content.html.erb
+++ b/app/views/contents/_content.html.erb
@@ -2,7 +2,7 @@
   <% contents.each_slice(3) do |contents| %>
     <div class="grid">
       <% contents.each do |content| %>
-        <a class="published_content">
+        <a class="published_content" href="<%= content_path(content) %>">
           <article>
             <h5> <%= content.name %>  </h5>
           </article>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -1,0 +1,30 @@
+<section>
+  <div class="grid contents">
+    <div>
+      <a href="post.html">
+        <article>
+          <h3 class="text-center"><%= @content.name %></h3>
+        </article>
+      </a>
+    </div>
+  </div>
+
+  <div class="grid contents">
+    <div>
+      <iframe width="100%" height="675" src="https://www.youtube.com/embed/L9rtI1YPRwY?controls=0"
+        title="YouTube video player" frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowfullscreen></iframe>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="grid contents">
+    <div>
+      <p>
+        <%= @content.body %>
+      </p>
+    </div>
+  </div>
+</section>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,0 +1,1 @@
+<h2 class='text-center'>Conteúdo não encontrado!</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
   root "home#index"
+
+  resources :contents, only: %i[show]
 end

--- a/spec/features/visits_content_page_spec.rb
+++ b/spec/features/visits_content_page_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+feature 'Visits Content page' do
+  context 'when visit page' do
+    scenario 'through of home page' do
+      content = create(:content, status: :published)
+
+      visit root_path
+      click_on content.name
+
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content(content.name)
+    end
+
+    scenario 'directly' do
+      content = create(:content, status: :published)
+
+      visit content_path(content)
+
+      expect(page).to have_content(content.name)
+      expect(page).to have_content(content.body)
+    end
+
+    scenario 'should show the post it was published' do
+      content = create(:content, status: :draft)
+
+      visit content_path(content)
+
+      expect(page).to have_content('Conteúdo não encontrado!')
+      expect(page).not_to have_content(content.name)
+      expect(page).not_to have_content(content.body)
+    end
+  end
+end


### PR DESCRIPTION
**problema**
Visitante não consegue visitar contéudos para obter informações.

**solução**
Criar página única para cada contéudo e previnir que se o conteúdo estiver em outro status além de publicado, o visitante não deverá ter acesso.

Close #86 